### PR TITLE
Add support for require()

### DIFF
--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -28,6 +28,22 @@ describe('Babel Inline Import - Plugin', () => {
 
         expect(transformedCode.code).to.equal(`/* babel-plugin-inline-import './fixtures/${filename}' */var SomeExample = '${base64data}';`);
       });
+
+      it('transforms the require statements into a var w/ the intended content', () => {
+        const transformedCode = babel.transform(`const SomeExample = require('./fixtures/${filename}');`, {
+          filename: __filename,
+          plugins: [[
+            BabelInlineImportDataURI, {
+              extensions: [
+                '.svg',
+                '.png',
+              ]
+            }
+          ]]
+        });
+
+        expect(transformedCode.code).to.equal(`var SomeExample = '${base64data}';`);
+      })
     });
 
     it('accepts different extensions', () => {


### PR DESCRIPTION
Extends support to include `require()` calls, so

```javascript
var x = require('foo.svg');
```

transforms to:

```javascript
var x = 'data:image/svg.....'
```