### PR TITLE
Allow `extensions` option to be a list

### DIFF
--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -11,9 +11,11 @@ export default class BabelInlineImportHelper {
   static root = global.rootPath || process.cwd();
 
   static shouldBeInlined(givenPath, extensions) {
-    const accept = (typeof extensions === 'string')
-      ? [extensions]
-      : (extensions || BabelInlineImportHelper.extensions);
+    const accept = (typeof extensions === "object" && extensions.length)?
+      extensions:
+      (typeof extensions === 'string')
+        ? [extensions]
+        : (extensions || BabelInlineImportHelper.extensions);
 
     for (const extension of accept) {
       if (givenPath.endsWith(extension)) {


### PR DESCRIPTION
Use example:
```json
  "babel": {
    "plugins": [
      "babel-plugin-macros",
      "@babel/plugin-transform-react-jsx",
      [
        "babel-plugin-inline-import-data-uri",
        {
          "extensions": [".svg", ".gif", ".png"]
        }
      ]
    ],
```